### PR TITLE
Added possibility to store artfacts

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -18,6 +18,19 @@ jobs:
         - name: Checkout code
           uses: actions/checkout@v4
 
+        - name: Setup the environment
+          uses: ./.github/actions/build_env
+
+        - name: Build the package
+          run: uv build
+
+        - name: Upload dist files
+          uses: actions/upload-artifact@v4
+          with:
+            name: python-package-distributions
+            path: dist/
+            retention-days: 7
+
         - name: Get version from pyproject.toml
           id: get_version
           run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup the environment
-        uses: ./.github/actions/build_env
-
-      - name: Build package
-        run: uv build 
+      - name: Download dist files
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
 
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for releasing a Python package by improving the build and artifact management process. The changes separate the build step into the `github_release.yml` workflow and streamline the `release.yml` workflow to download pre-built artifacts instead of rebuilding the package.

### Workflow improvements:

* [`.github/workflows/github_release.yml`](diffhunk://#diff-50460b48386c40745dfa49afea4d6ad2791112d554bb09a1a39fc06adbca9536R21-R33): Added steps to set up the environment, build the package, and upload distribution files as artifacts. This ensures the build process is handled in the release preparation workflow.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L28-R32): Removed the environment setup and build steps and replaced them with a step to download the pre-built artifacts. This simplifies the release workflow by reusing artifacts generated in the `github_release.yml` workflow.